### PR TITLE
Split flang and libflang

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,12 +18,3 @@ if errorlevel 1 exit 1
 nmake
 if errorlevel 1 exit 1
 
-nmake install
-if errorlevel 1 exit 1
-
-:: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
-:: This will allow them to be run on environment activation.
-FOR %%F IN (activate deactivate) DO (
-    IF NOT EXIST %PREFIX%\etc\conda\%%F.d MKDIR %PREFIX%\etc\conda\%%F.d
-    COPY %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
-)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,10 +10,3 @@ cmake \
 
 
 make -j${CPU_COUNT}
-make install
-
-for CHANGE in "activate" "deactivate"
-do
-    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
-done

--- a/recipe/install_flang.bat
+++ b/recipe/install_flang.bat
@@ -1,0 +1,14 @@
+cd %SRC_DIR%\build
+nmake install
+if errorlevel 1 exit 1
+
+rm %LIBRARY_BIN%\flang.dll
+rm %LIBRARY_BIN%\flangrti.dll
+rm %LIBRARY_BIN%\ompstub.dll
+
+:: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
+:: This will allow them to be run on environment activation.
+FOR %%F IN (activate deactivate) DO (
+    IF NOT EXIST %PREFIX%\etc\conda\%%F.d MKDIR %PREFIX%\etc\conda\%%F.d
+    COPY %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+)

--- a/recipe/install_flang.bat
+++ b/recipe/install_flang.bat
@@ -1,4 +1,5 @@
 cd %SRC_DIR%\build
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
 nmake install
 if errorlevel 1 exit 1
 

--- a/recipe/install_flang.sh
+++ b/recipe/install_flang.sh
@@ -1,0 +1,11 @@
+cd $SRC_DIR/build
+make install
+rm $PREFIX/lib/libflang${SHLIB_EXT}
+rm $PREFIX/lib/libflangrti${SHLIB_EXT}
+rm $PREFIX/lib/libompstub${SHLIB_EXT}
+
+for CHANGE in "activate" "deactivate"
+do
+    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+done

--- a/recipe/install_libflang.bat
+++ b/recipe/install_libflang.bat
@@ -1,0 +1,3 @@
+cp %SRC_DIR%/build/bin/flang.dll %LIBRARY_BIN%\
+cp %SRC_DIR%/build/bin/flangrti.dll %LIBRARY_BIN%\
+cp %SRC_DIR%/build/bin/ompstub.dll %LIBRARY_BIN%\

--- a/recipe/install_libflang.sh
+++ b/recipe/install_libflang.sh
@@ -1,0 +1,3 @@
+cp $SRC_DIR/build/lib/libflang${SHLIB_EXT} $PREFIX/lib
+cp $SRC_DIR/build/lib/libflangrti${SHLIB_EXT} $PREFIX/lib
+cp $SRC_DIR/build/lib/libompstub${SHLIB_EXT} $PREFIX/lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,9 +40,9 @@ requirements:
 outputs:
   - name: libflang
     files:
-      - "%LIBRARY_BIN%\flang.dll"             # [win]
-      - "%LIBRARY_BIN%\flangrti.dll"          # [win]
-      - "%LIBRARY_BIN%\ompstub.dll"           # [win]
+      - "%LIBRARY_BIN%\\flang.dll"             # [win]
+      - "%LIBRARY_BIN%\\flangrti.dll"          # [win]
+      - "%LIBRARY_BIN%\\ompstub.dll"           # [win]
       - $PREFIX/lib/libflang${SHLIB_EXT}      # [unix]
       - $PREFIX/lib/libflangrti${SHLIB_EXT}   # [unix]
       - $PREFIX/lib/libompstub${SHLIB_EXT}    # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set flang_commit = "ab1423f97274b472970efd53e01800a6d4f137f5" %}
 {% set version = "5.0.0" %}
 {% set sha256 = "01264da25bac23e27ca9298bbfd41f7226854247e92a3edea6f28decf42c7b09" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 package:
   name: flang
@@ -35,6 +35,19 @@ requirements:
     - clangdev =={{ version }}
     - openmp =={{ version }}
     - vc 14     # [win]
+    - libflang {{ version }} {{ build_number }}
+
+outputs:
+  - name: libflang
+    files:
+      - "%LIBRARY_BIN%\flang.dll"             # [win]
+      - "%LIBRARY_BIN%\flangrti.dll"          # [win]
+      - "%LIBRARY_BIN%\ompstub.dll"           # [win]
+      - $PREFIX/lib/libflang${SHLIB_EXT}      # [unix]
+      - $PREFIX/lib/libflangrti${SHLIB_EXT}   # [unix]
+      - $PREFIX/lib/libompstub${SHLIB_EXT}    # [unix]
+    requirements:
+      - vc 14     # [win]
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,23 +31,21 @@ requirements:
     - llvmdev =={{ version }}
     - flang-meta
     - vc 14     # [win]
-  run:
-    - clangdev =={{ version }}
-    - openmp =={{ version }}
-    - vc 14     # [win]
-    - libflang {{ version }} {{ build_number }}
 
 outputs:
   - name: libflang
-    files:
-      - "%LIBRARY_BIN%\\flang.dll"             # [win]
-      - "%LIBRARY_BIN%\\flangrti.dll"          # [win]
-      - "%LIBRARY_BIN%\\ompstub.dll"           # [win]
-      - $PREFIX/lib/libflang${SHLIB_EXT}      # [unix]
-      - $PREFIX/lib/libflangrti${SHLIB_EXT}   # [unix]
-      - $PREFIX/lib/libompstub${SHLIB_EXT}    # [unix]
+    script: install_libflang.sh   # [unix]
+    script: install_libflang.bat  # [win]
     requirements:
-      - vc 14     # [win]
+      - vc 14                     # [win]
+  - name: flang
+    script: install_flang.sh      # [unix]
+    script: install_flang.bat     # [win]
+    requirements:
+      - clangdev =={{ version }}
+      - openmp =={{ version }}
+      - vc 14                     # [win]
+      - libflang {{ version }} {{ build_number }}
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,8 @@ outputs:
       - clangdev =={{ version }}
       - openmp =={{ version }}
       - vc 14                     # [win]
-      - libflang {{ version }} {{ build_number }}
+      - libflang {{ version }} {{ build_number }}       # [unix]
+      - libflang {{ version }} vc14_{{ build_number }}  # [win]
 
 test:
   files:


### PR DESCRIPTION
This creates 2 packages `libflang` and `flang` and where the latter depends on the former. This is done because projects compiled with flang can depend only on `libflang` at runtime.