### PR TITLE
[dev] flang 19.0.0.dev0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -9,9 +9,9 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_dev,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -26,4 +26,4 @@ zip_keys:
 - - c_stdlib_version
   - cdt_name
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -12,3 +12,5 @@ target_platform:
 - win-64
 zlib:
 - '1'
+zstd:
+- '1.5'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -3,12 +3,12 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_dev,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_dev
 cxx_compiler:
 - vs2019
 target_platform:
 - win-64
 zlib:
-- '1.2'
+- '1'

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -69,6 +69,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -53,6 +53,11 @@ echo Building recipe
 conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
+call :start_group "Inspecting artifacts"
+:: inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+WHERE inspect_artifacts >nul 2>nul && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+call :end_group
+
 :: Prepare some environment variables for the upload step
 if /i "%CI%" == "github_actions" (
     set "FEEDSTOCK_NAME=%GITHUB_REPOSITORY:*/=%"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-flang_linux--64-green.svg)](https://anaconda.org/conda-forge/flang_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/flang_linux-64.svg)](https://anaconda.org/conda-forge/flang_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/flang_linux-64.svg)](https://anaconda.org/conda-forge/flang_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/flang_linux-64.svg)](https://anaconda.org/conda-forge/flang_linux-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-flang_win--64-green.svg)](https://anaconda.org/conda-forge/flang_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/flang_win-64.svg)](https://anaconda.org/conda-forge/flang_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/flang_win-64.svg)](https://anaconda.org/conda-forge/flang_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/flang_win-64.svg)](https://anaconda.org/conda-forge/flang_win-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libflang-green.svg)](https://anaconda.org/conda-forge/libflang) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libflang.svg)](https://anaconda.org/conda-forge/libflang) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libflang.svg)](https://anaconda.org/conda-forge/libflang) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libflang.svg)](https://anaconda.org/conda-forge/libflang) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-libfortran--main-green.svg)](https://anaconda.org/conda-forge/libfortran-main) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libfortran-main.svg)](https://anaconda.org/conda-forge/libfortran-main) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libfortran-main.svg)](https://anaconda.org/conda-forge/libfortran-main) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libfortran-main.svg)](https://anaconda.org/conda-forge/libfortran-main) |
 
 Installing flang
 ================
@@ -71,16 +70,16 @@ conda config --add channels conda-forge/label/llvm_dev
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge/label/llvm_dev` channel has been enabled, `flang, flang_linux-64, flang_win-64, libflang, libfortran-main` can be installed with `conda`:
+Once the `conda-forge/label/llvm_dev` channel has been enabled, `flang, flang_linux-64, flang_win-64, libflang` can be installed with `conda`:
 
 ```
-conda install flang flang_linux-64 flang_win-64 libflang libfortran-main
+conda install flang flang_linux-64 flang_win-64 libflang
 ```
 
 or with `mamba`:
 
 ```
-mamba install flang flang_linux-64 flang_win-64 libflang libfortran-main
+mamba install flang flang_linux-64 flang_win-64 libflang
 ```
 
 It is possible to list all of the versions of `flang` available on your platform with `conda`:

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ Current release info
 Installing flang
 ================
 
-Installing `flang` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `flang` from the `conda-forge/label/llvm_dev` channel can be achieved by adding `conda-forge/label/llvm_dev` to your channels with:
 
 ```
-conda config --add channels conda-forge
+conda config --add channels conda-forge/label/llvm_dev
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `flang, flang_linux-64, flang_win-64, libflang, libfortran-main` can be installed with `conda`:
+Once the `conda-forge/label/llvm_dev` channel has been enabled, `flang, flang_linux-64, flang_win-64, libflang, libfortran-main` can be installed with `conda`:
 
 ```
 conda install flang flang_linux-64 flang_win-64 libflang libfortran-main
@@ -86,26 +86,26 @@ mamba install flang flang_linux-64 flang_win-64 libflang libfortran-main
 It is possible to list all of the versions of `flang` available on your platform with `conda`:
 
 ```
-conda search flang --channel conda-forge
+conda search flang --channel conda-forge/label/llvm_dev
 ```
 
 or with `mamba`:
 
 ```
-mamba search flang --channel conda-forge
+mamba search flang --channel conda-forge/label/llvm_dev
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search flang --channel conda-forge
+mamba repoquery search flang --channel conda-forge/label/llvm_dev
 
 # List packages depending on `flang`:
-mamba repoquery whoneeds flang --channel conda-forge
+mamba repoquery whoneeds flang --channel conda-forge/label/llvm_dev
 
 # List dependencies of `flang`:
-mamba repoquery depends flang --channel conda-forge
+mamba repoquery depends flang --channel conda-forge/label/llvm_dev
 ```
 
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,8 @@
 @echo on
 
+:: show CPU arch to detect slow CI agents early (rather than wait for 6h timeout)
+python -c "import numpy; numpy.show_config()"
+
 mkdir build
 cd build
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,6 +18,7 @@ cmake -G "Ninja" ^
     -DLLVM_EXTERNAL_LIT=%LIBRARY_BIN%/lit ^
     -DLLVM_LIT_ARGS=-v ^
     -DLLVM_CMAKE_DIR=%LIBRARY_LIB%/cmake/llvm ^
+    -DLLVM_DIR=%LIBRARY_LIB%/cmake/llvm ^
     -DCLANG_DIR=%LIBRARY_LIB%/cmake/clang ^
     -DFLANG_INCLUDE_TESTS=OFF ^
     -DMLIR_DIR=%LIBRARY_LIB%/cmake/mlir ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -ex
 
+# show CPU arch to detect slow CI agents early (rather than wait for 6h timeout)
+python -c "import numpy; numpy.show_config()"
+
 mkdir build
 cd build
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,7 @@ cmake -G Ninja \
     -DLLVM_EXTERNAL_LIT=$PREFIX/bin/lit \
     -DLLVM_LIT_ARGS=-v \
     -DLLVM_CMAKE_DIR=$PREFIX/lib/cmake/llvm \
+    -DLLVM_DIR=$PREFIX/lib/cmake/llvm \
     -DCLANG_DIR=$PREFIX/lib/cmake/clang \
     -DFLANG_INCLUDE_TESTS=OFF \
     -DMLIR_DIR=$PREFIX/lib/cmake/mlir \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,7 @@
 c_stdlib_version:       # [linux]
   - "2.17"              # [linux]
+
+channel_targets:
+  - conda-forge llvm_dev
+channel_sources:
+  - conda-forge/label/llvm_dev,conda-forge

--- a/recipe/install_libfortran_main.bat
+++ b/recipe/install_libfortran_main.bat
@@ -1,3 +1,0 @@
-@echo on
-
-cp build\lib\Fortran_main.lib %LIBRARY_LIB%

--- a/recipe/install_libfortran_main.sh
+++ b/recipe/install_libfortran_main.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -ex
-
-cp $SRC_DIR/build/lib/libFortran_main.a $PREFIX/lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "18.1.7" %}
+{% set version = "19.0.0.dev0" %}
 
 package:
   name: flang-split
   version: {{ version }}
 
 source:
-  url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: b60df7cbe02cef2523f7357120fb0d46cbb443791cde3a5fb36b82c335c0afc9
+  # url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
+  url: https://github.com/llvm/llvm-project/archive/1754651dd150139d64cdae190afe1faabf69a403.tar.gz
+  sha256: e69a1b15a7972a72334229d597b78ee56a5ed16aa62299df23ecd239dfd3a8f5
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,6 +88,7 @@ outputs:
         - libclang-cpp =={{ version }}
         # ninja really wants to find z.lib on win
         - zlib  # [win]
+        - zstd  # [win]
         - {{ pin_subpackage('libflang', exact=True) }}
       run:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,25 +63,6 @@ outputs:
         # static lib on win (fails to export symbols for shared build)
         - if not exist %LIBRARY_LIB%\FortranRuntime.lib exit 1  # [win]
 
-  - name: libfortran-main
-    script: install_libfortran_main.sh  # [unix]
-    script: install_libfortran_main.bat  # [win]
-    requirements:
-      build:
-        # if there's no build env, windows fails with EnvironmentLocationNotFound (what?!)
-        - {{ compiler('c') }}    # [win]
-        - {{ stdlib('c') }}      # [win]
-        - {{ compiler('cxx') }}  # [win]
-      host:
-        # this is just here to have a non-empty host environment
-        - {{ pin_subpackage('libflang', exact=True) }}
-      run:
-        # not sure what we need here
-    test:
-      commands:
-        - test -f $PREFIX/lib/libFortran_main.a                 # [unix]
-        - if not exist %LIBRARY_LIB%\Fortran_main.lib exit 1    # [win]
-
   - name: flang
     script: install_flang.sh  # [unix]
     script: install_flang.bat  # [win]
@@ -108,13 +89,11 @@ outputs:
         # ninja really wants to find z.lib on win
         - zlib  # [win]
         - {{ pin_subpackage('libflang', exact=True) }}
-        - {{ pin_subpackage('libfortran-main', exact=True) }}
       run:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]
         - clangdev =={{ version }}
         - llvm-openmp =={{ version }}
         - {{ pin_subpackage('libflang', exact=True) }}
-        - {{ pin_subpackage('libfortran-main', exact=True) }}
     test:
       requires:
         - {{ compiler('c') }}       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - cmake
     - ninja
     - mlir =={{ version }}     # [build_platform != target_platform]
+    # for showing CPU info of CI agent
+    - numpy *
   host:
     - clangdev =={{ version }}
     - compiler-rt =={{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,6 +70,7 @@ outputs:
       build:
         # if there's no build env, windows fails with EnvironmentLocationNotFound (what?!)
         - {{ compiler('c') }}    # [win]
+        - {{ stdlib('c') }}      # [win]
         - {{ compiler('cxx') }}  # [win]
       host:
         # this is just here to have a non-empty host environment

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
 
 source:
   # url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  url: https://github.com/llvm/llvm-project/archive/1754651dd150139d64cdae190afe1faabf69a403.tar.gz
-  sha256: e69a1b15a7972a72334229d597b78ee56a5ed16aa62299df23ecd239dfd3a8f5
+  url: https://github.com/llvm/llvm-project/archive/edf5782f1780f480c3ae3fc0a44bf5432f9aa48b.tar.gz
+  sha256: 34129ca709be4fcc1cf3ae5565cb4ed93e497594923f32603e545aa5cd57bb7b
 
 build:
-  number: 0
+  number: 1
   # intentionally only windows (main target) & linux (debuggability)
   skip: true  # [osx]
   track_features:


### PR DESCRIPTION
Match `dev` branch with llvmdev feedstock; build a consistent stack from LLVM main, in order to test newer flang against scipy