### PR TITLE
[dev] remove openmp dep from flang

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 34129ca709be4fcc1cf3ae5565cb4ed93e497594923f32603e545aa5cd57bb7b
 
 build:
-  number: 1
+  number: 2
   # intentionally only windows (main target) & linux (debuggability)
   skip: true  # [osx]
   track_features:
@@ -82,7 +82,6 @@ outputs:
       host:
         - clangdev =={{ version }}
         - compiler-rt =={{ version }}
-        - llvm-openmp =={{ version }}
         - llvmdev =={{ version }}
         - mlir =={{ version }}
         # for required run-exports
@@ -95,7 +94,6 @@ outputs:
       run:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]
         - clangdev =={{ version }}
-        - llvm-openmp =={{ version }}
         - {{ pin_subpackage('libflang', exact=True) }}
     test:
       requires:


### PR DESCRIPTION
Not necessary according to link check, and leads to circularity with needing to use a fortran compiler for some openmp features: https://github.com/conda-forge/openmp-feedstock/pull/132