### PR TITLE
Remove openmp dependency from flang

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -12,3 +12,5 @@ target_platform:
 - win-64
 zlib:
 - '1'
+zstd:
+- '1.5'

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,8 @@
 @echo on
 
+:: show CPU arch to detect slow CI agents early (rather than wait for 6h timeout)
+python -c "import numpy; numpy.show_config()"
+
 mkdir build
 cd build
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -ex
 
+# show CPU arch to detect slow CI agents early (rather than wait for 6h timeout)
+python -c "import numpy; numpy.show_config()"
+
 mkdir build
 cd build
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - cmake
     - ninja
     - mlir =={{ version }}     # [build_platform != target_platform]
+    # for showing CPU info of CI agent
+    - numpy *
   host:
     - clangdev =={{ version }}
     - compiler-rt =={{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 09c08693a9afd6236f27a2ebae62cda656eba19021ef3f94d59e931d662d4856
 
 build:
-  number: 0
+  number: 1
   # intentionally only windows (main target) & linux (debuggability)
   skip: true  # [osx]
   track_features:
@@ -100,7 +100,6 @@ outputs:
       host:
         - clangdev =={{ version }}
         - compiler-rt =={{ version }}
-        - llvm-openmp =={{ version }}
         - llvmdev =={{ version }}
         - mlir =={{ version }}
         # for required run-exports
@@ -114,7 +113,6 @@ outputs:
       run:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]
         - clangdev =={{ version }}
-        - llvm-openmp =={{ version }}
         - {{ pin_subpackage('libflang', exact=True) }}
         - {{ pin_subpackage('libfortran-main', exact=True) }}
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,6 +106,7 @@ outputs:
         - libclang-cpp =={{ version }}
         # ninja really wants to find z.lib on win
         - zlib  # [win]
+        - zstd  # [win]
         - {{ pin_subpackage('libflang', exact=True) }}
         - {{ pin_subpackage('libfortran-main', exact=True) }}
       run:


### PR DESCRIPTION
\+ some fixlets that accumulated on the dev-branch. openmp isn't actually needed at runtime, and depending on it causes a circularity if we want to build the fortran bits of LLVM's openmp with flang.